### PR TITLE
Do not use the same ServiceCollection as the IHost

### DIFF
--- a/src/Spectre.Console.Extensions.Hosting/Infrastructure/HostEnabledCommandApp.cs
+++ b/src/Spectre.Console.Extensions.Hosting/Infrastructure/HostEnabledCommandApp.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Hosting;
+using Spectre.Console.Cli;
+
+namespace Spectre.Console.Extensions.Hosting.Infrastructure;
+
+internal class HostEnabledCommandApp :  IHostEnabledCommandApp
+{
+    private readonly TypeRegistrar _typeRegistrar;
+    private readonly CommandApp _underlyingCommandApp;
+
+    public HostEnabledCommandApp(TypeRegistrar typeRegistrar)
+    {
+        _typeRegistrar = typeRegistrar;
+        _underlyingCommandApp = new CommandApp(typeRegistrar);
+    }
+
+    public void Configure(Action<IConfigurator> configuration)
+    {
+        _underlyingCommandApp.Configure(configuration);
+    }
+
+    public int Run(IEnumerable<string> args)
+    {
+        return _underlyingCommandApp.Run(args);
+    }
+
+    public async Task<int> RunAsync(IEnumerable<string> args)
+    {
+        return await _underlyingCommandApp.RunAsync(args);
+    }
+
+    public void SetHost(IHost host)
+    {
+        _typeRegistrar.SetHost(host);
+    }
+}
+
+internal class HostEnabledCommandApp<TDefaultCommand> :  IHostEnabledCommandApp
+where TDefaultCommand: class, ICommand
+{
+    private readonly TypeRegistrar _typeRegistrar;
+    private readonly CommandApp<TDefaultCommand> _underlyingCommandApp;
+
+    public HostEnabledCommandApp(TypeRegistrar typeRegistrar)
+    {
+        _typeRegistrar = typeRegistrar;
+        _underlyingCommandApp = new CommandApp<TDefaultCommand>(typeRegistrar);
+    }
+
+    public void Configure(Action<IConfigurator> configuration)
+    {
+        _underlyingCommandApp.Configure(configuration);
+    }
+
+    public int Run(IEnumerable<string> args)
+    {
+        return _underlyingCommandApp.Run(args);
+    }
+
+    public async Task<int> RunAsync(IEnumerable<string> args)
+    {
+        return await _underlyingCommandApp.RunAsync(args);
+    }
+
+    public void SetHost(IHost host)
+    {
+        _typeRegistrar.SetHost(host);
+    }
+}

--- a/src/Spectre.Console.Extensions.Hosting/Infrastructure/IHostEnabledCommandApp.cs
+++ b/src/Spectre.Console.Extensions.Hosting/Infrastructure/IHostEnabledCommandApp.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Hosting;
+using Spectre.Console.Cli;
+
+namespace Spectre.Console.Extensions.Hosting.Infrastructure;
+
+public interface IHostEnabledCommandApp : ICommandApp
+{
+    void SetHost(IHost host);
+}

--- a/src/Spectre.Console.Extensions.Hosting/SpectreConsoleHostBuilderExtensions.cs
+++ b/src/Spectre.Console.Extensions.Hosting/SpectreConsoleHostBuilderExtensions.cs
@@ -21,15 +21,14 @@ public static class SpectreConsoleHostBuilderExtensions
     public static IHostBuilder UseSpectreConsole(this IHostBuilder builder, Action<IConfigurator> configureCommandApp)
     {
         builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        var command = new HostEnabledCommandApp(new TypeRegistrar(builder));
+        command.Configure(configureCommandApp);
 
         builder.ConfigureServices((_, collection) =>
-            {
-                var command = new CommandApp(new TypeRegistrar(collection));
-                command.Configure(configureCommandApp);
-                collection.AddSingleton<ICommandApp>(command);
-                collection.AddHostedService<SpectreConsoleWorker>();
-            }
-        );
+        {
+            collection.AddSingleton<IHostEnabledCommandApp>(command);
+            collection.AddHostedService<SpectreConsoleWorker>();
+        });
 
         return builder;
     }
@@ -48,18 +47,17 @@ public static class SpectreConsoleHostBuilderExtensions
     {
         builder = builder ?? throw new ArgumentNullException(nameof(builder));
 
-        builder.ConfigureServices((_, collection) =>
-            {
-                var command = new CommandApp<TDefaultCommand>(new TypeRegistrar(collection));
-                if (configureCommandApp != null)
-                {
-                    command.Configure(configureCommandApp);
-                }
+        var command = new HostEnabledCommandApp<TDefaultCommand>(new TypeRegistrar(builder));
+        if (configureCommandApp != null)
+        {
+            command.Configure(configureCommandApp);
+        }
 
-                collection.AddSingleton<ICommandApp>(command);
-                collection.AddHostedService<SpectreConsoleWorker>();
-            }
-        );
+        builder.ConfigureServices((_, collection) =>
+        {
+            collection.AddSingleton<IHostEnabledCommandApp>(command);
+            collection.AddHostedService<SpectreConsoleWorker>();
+        });
 
         return builder;
     }

--- a/src/Spectre.Console.Extensions.Hosting/Worker/SpectreConsoleWorker.cs
+++ b/src/Spectre.Console.Extensions.Hosting/Worker/SpectreConsoleWorker.cs
@@ -1,22 +1,27 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Spectre.Console.Cli;
+using Spectre.Console.Extensions.Hosting.Infrastructure;
 
 namespace Spectre.Console.Extensions.Hosting.Worker;
 
 public class SpectreConsoleWorker : IHostedService
 {
-    private readonly ICommandApp _commandApp;
+    private readonly IHostEnabledCommandApp _commandApp;
     private readonly IHostApplicationLifetime _hostLifetime;
+    private readonly IHost _host;
     private readonly ILogger<SpectreConsoleWorker> _logger;
     private int _exitCode;
 
-    public SpectreConsoleWorker(ILogger<SpectreConsoleWorker> logger, ICommandApp commandApp,
-        IHostApplicationLifetime hostLifetime)
+    public SpectreConsoleWorker(
+        ILogger<SpectreConsoleWorker> logger,
+        IHostEnabledCommandApp commandApp,
+        IHostApplicationLifetime hostLifetime,
+        IHost host)
     {
         _logger = logger;
         _commandApp = commandApp;
         _hostLifetime = hostLifetime;
+        _host = host;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -26,6 +31,7 @@ public class SpectreConsoleWorker : IHostedService
             try
             {
                 var args = GetArgs();
+                _commandApp.SetHost(_host);
                 await Task.Delay(100, cancellationToken); //Just to let Microsoft.Hosting finish.
                 _exitCode = await _commandApp.RunAsync(args);
             }


### PR DESCRIPTION
This most probably fixes the issue, described in https://github.com/spectreconsole/spectre.console/issues/1267

The main change is that the `IServiceCollection` provided by the `IHostBuilder` is not modified by spectre.console, and not directly used by the `ITypeResolver`. Instead, we're using an unrelated `IServiceCollection` that will be modified by spectre.console. To have the registrations of the `IServiceCollection` from the `IHostBuilder` available "in" spectre.console, all registrations are "copied", as soon as the `IHost` was built. 