### PR TITLE
Fixed tpyo in Readme File

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ It is planned to further adopt CLI examples from [Spectre.Console].
 
 ## Contributing
 
-pectre.Console.Extensions.Hosting follows the [Contributor Covenant][contrib-covenant] Code of Conduct.
+Spectre.Console.Extensions.Hosting follows the [Contributor Covenant][contrib-covenant] Code of Conduct.
 
 We accept Pull Requests.
 


### PR DESCRIPTION
Was perusing the repo over lunch and noticed this missing S in the readme on the NuGet page and this readme.