### PR TITLE
Expand framework targets to .NET 10.0, 9.0, and 8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        os: [ windows-2022, ubuntu-22.04, macos-12 ]
+        os: [ windows-2022, ubuntu-24.04, macos-14 ]
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
 
       - name: Fetch all tags and branches
         run: git fetch --prune --unshallow
 
-      - uses: actions/setup-dotnet@v3.4.2
+      - uses: actions/setup-dotnet@v4.1.0
         with:
           dotnet-version: |
             2.1.818
@@ -43,22 +43,25 @@ jobs:
             5.0.x
             6.0.x
             7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Cache Tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.0
         with:
           path: tools
           key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
 
       - name: Build project
-        uses: cake-build/cake-action@v1
+        uses: cake-build/cake-action@v3.0.1
         with:
           script-path: recipe.cake
           target: CI
           cake-version: 1.3.0
 
       - name: Upload Issues
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         with:
           if-no-files-found: warn
           name: ${{ matrix.os }} Issues
@@ -67,7 +70,7 @@ jobs:
             BuildArtifacts/**/coverlet/*.xml
 
       - name: Upload Packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         if: runner.os == 'Windows'
         with:
           if-no-files-found: warn

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "projects": [ "src" ],
   "sdk": {
     "allowPrerelease": true,
-    "version": "7.0.410",
+    "version": "10.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Samples/SingleCommand/Commands/DefaultCommand.cs
+++ b/src/Samples/SingleCommand/Commands/DefaultCommand.cs
@@ -13,7 +13,7 @@ public sealed class DefaultCommand : Command<DefaultCommand.Settings>
         _greeter = greeter ?? throw new ArgumentNullException(nameof(greeter));
     }
 
-    public override int Execute([NotNull] CommandContext context, [NotNull] Settings settings)
+    public override int Execute([NotNull] CommandContext context, [NotNull] Settings settings, [NotNull] CancellationToken cancellationToken)
     {
         _greeter.Greet(settings.Name);
         return 0;

--- a/src/Samples/SingleCommand/SingleCommand.csproj
+++ b/src/Samples/SingleCommand/SingleCommand.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SingleCommand</RootNamespace>

--- a/src/Spectre.Console.Extensions.Hosting.sln
+++ b/src/Spectre.Console.Extensions.Hosting.sln
@@ -6,6 +6,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleCommand", "Samples\Si
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{3EEF9DAB-A839-40AB-B67A-54A88D753B21}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{47DE6B49-FEDA-4921-AC0E-5F5CD0C4796B}"
+	ProjectSection(SolutionItems) = preProject
+		..\global.json = ..\global.json
+		..\.github\renovate.json = ..\.github\renovate.json
+		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Spectre.Console.Extensions.Hosting/Spectre.Console.Extensions.Hosting.csproj
+++ b/src/Spectre.Console.Extensions.Hosting/Spectre.Console.Extensions.Hosting.csproj
@@ -1,12 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0</TargetFrameworks>
-    <LangVersion>10</LangVersion>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Spectre.Console.Extensions.Hosting</RootNamespace>
   </PropertyGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PropertyGroup>
+        <LangVersion>10</LangVersion>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <LangVersion>default</LangVersion>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <PropertyGroup>
     <StartYear>2022</StartYear>
     <EndYear>$([System.DateTime]::Today.Year)</EndYear>


### PR DESCRIPTION
This pull request updates the project to support newer .NET versions and improves compatibility across multiple frameworks. The most significant changes are the addition of .NET 10.0, 9.0, and 8.0 targets, and adjustments to language version settings to ensure proper compilation. There is also a minor API change to the command execution method.

**Framework and language version updates:**

* Expanded supported target frameworks in `Spectre.Console.Extensions.Hosting.csproj` to include `net10.0`, `net9.0`, and `net8.0`, and added conditional logic to set the `LangVersion` based on the target framework.
* Updated the target framework in `SingleCommand.csproj` from `net6.0` to `net10.0`.

**API changes:**

* Modified the signature of the `Execute` method in `DefaultCommand` to accept an additional `CancellationToken` parameter, improving support for cancellation in command execution.